### PR TITLE
Add container image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Build Stage
+FROM rust:1.56.0 AS builder
+WORKDIR /usr/src/
+RUN rustup target add x86_64-unknown-linux-musl
+
+WORKDIR /usr/src/manytasks
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+
+RUN cargo install --target x86_64-unknown-linux-musl --path .
+
+# Bundle Stage
+FROM scratch
+COPY --from=builder /usr/local/cargo/bin/manytasks /bin/manytasks
+USER 1000
+ENTRYPOINT ["/bin/manytasks"]


### PR DESCRIPTION
Add a `Dockerfile` for building a container image. This was about 4MiB when I tried it.


- `podman build -t manytasks:latest .`
- `docker build -t manytasks:latest .`